### PR TITLE
eval_validation_set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 
 coco_val_images_2017/
+
 output_dir/
 
 

--- a/init_setup_1.md
+++ b/init_setup_1.md
@@ -1,5 +1,12 @@
 
 
+### Run the Training Code 
+~~~
+(env2_det2) $ python src/det2_2.py > output_dir/terminal_logs/term_det2_2__11_2_1900h_TRAIN_100_.log
+
+~~~
+
+
 ### Am well aware the below CODE / TEXT is Not Python 
 
 ```python


### PR DESCRIPTION
  # ORIGINAL COMMENT Detectron2 -- Inference should use the config with parameters that are used in training
    # cfg now already contains everything we've set previously. We changed it a little bit for inference:
    
    For Running the EVALUATION / VALIDATION on the VALIDATION SET we are required to again - REGISTER the VALIDATION Dataset separately , from the TRAIN data. 
    As an aside - for TEST DATA runs - we dont need to REGISTER the data again .